### PR TITLE
add system dependency libexpat to solve importerror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     libxrender1 \
+    libexpat1 \
     libxext6 \
     libx11-6 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
when running the docker image "import rdkit" raised this import error

ImportError: libexpat.so.1: cannot open shared object file: 

I added libexpat to the system dependencies in the docker file to solve this