### PR TITLE
Project-end fixes: report download, per-tab select-all, AD in API, /get_models

### DIFF
--- a/app.py
+++ b/app.py
@@ -559,6 +559,16 @@ def predict():
         log_prediction_time(used_ifp_model, len(smiles_list), elapsed_time)
         timing_stats = get_timing_stats()
 
+        # Generate a downloadable PDF report instead of re-rendering the page
+        if request.form.get('download_report'):
+            report_models = [model_info_dict[m] for m in model_names if m in model_info_dict]
+            # Drop the 'Structure' image column (col 0); keep SMILES + predictions as text
+            report_headers = headers[1:]
+            report_rows = [[row[1]] + [str(cell) for cell in row[2:]] for row in table_data]
+            report_buffer = create_report(report_models, report_headers, report_rows)
+            return send_file(report_buffer, as_attachment=True,
+                             download_name='qsprpred_report.pdf', mimetype='application/pdf')
+
         return render_template('index.html',
                                models=available_models,
                                data_dict=data_dict,
@@ -631,6 +641,11 @@ def create_report(model_info_list, headers, table_data):
     buffer.seek(0)
     return buffer
 
+@app.route('/get_models', methods=['GET'])
+def get_models():
+    """Return JSON metadata for all available models (name, target, task, algorithm, etc.)."""
+    return jsonify(extract_model_info(MODELS_DIR))
+
 @app.route('/api', methods=['POST'])
 def apipredict():
     data = request.json
@@ -645,6 +660,7 @@ def apipredict():
         return jsonify({'error': 'Invalid input: please provide a list of model names.'}), 400
 
     all_predictions = {}
+    all_ads = {}
 
     for model_name in models:
         model_path = os.path.join(MODELS_DIR, model_name, f"{model_name}_meta.json")
@@ -652,9 +668,14 @@ def apipredict():
             return jsonify({'error': f"Model {model_name} does not exist."}), 400
 
         model = SklearnModel.fromFile(model_path)
-        predictions = model.predictMols(smiles)
-        predictions_formatted = [f"{pred[0]:.4f}" for pred in predictions]
-        all_predictions[model_name] = predictions_formatted
+        # Include the applicability domain in the output when the model supports it (#41)
+        if getattr(model, 'applicabilityDomain', None):
+            predictions, ad = model.predictMols(smiles, use_applicability_domain=True)
+            all_ads[model_name] = [bool(ad[i][0]) for i in range(len(smiles))]
+        else:
+            predictions = model.predictMols(smiles)
+            all_ads[model_name] = None
+        all_predictions[model_name] = [f"{pred[0]:.4f}" for pred in predictions]
 
     # Format the result
     result = []
@@ -662,6 +683,8 @@ def apipredict():
         result_entry = {'smiles': smile}
         for model_name in models:
             result_entry[f'prediction ({model_name})'] = all_predictions[model_name][i]
+            if all_ads[model_name] is not None:
+                result_entry[f'within_applicability_domain ({model_name})'] = all_ads[model_name][i]
         result.append(result_entry)
 
     if output_format == 'text':

--- a/static/styles.css
+++ b/static/styles.css
@@ -245,3 +245,19 @@ th {
     color: #fff;
     background: #E6007E;
 }
+
+.select-all-btn {
+    margin: 6px 0 10px 0;
+    padding: 3px 12px;
+    font-size: 13px;
+    color: #E6007E;
+    background: none;
+    border: 1px solid #E6007E;
+    border-radius: 3px;
+    cursor: pointer;
+}
+
+.select-all-btn:hover {
+    color: #fff;
+    background: #E6007E;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -102,6 +102,19 @@
             }
         });
 
+        // Select or deselect all model checkboxes within the button's tab pane (#14)
+        function toggleTabModels(btn) {
+            var pane = btn.closest('.tab-pane');
+            if (!pane) return;
+            var boxes = pane.querySelectorAll('input[name="model"]');
+            var anyUnchecked = Array.prototype.some.call(boxes, function (b) { return !b.checked; });
+            boxes.forEach(function (b) {
+                b.checked = anyUnchecked;
+                b.dispatchEvent(new Event('change'));
+            });
+            btn.textContent = anyUnchecked ? 'Deselect all in this tab' : 'Select all in this tab';
+        }
+
         // Clear the persisted uploaded-file reference so the next run does not reuse it
         function clearUploadedFile() {
             var hidden = document.getElementById('uploaded_file_name');
@@ -134,6 +147,7 @@
             <div class="tab-content">
                 <div id="thyroid" class="tab-pane fade in active">
                     <label>MIE models:</label><sup><img src="/static/img/question-circle.svg" alt="Question circle" width="12" height="12" title="QSAR models for different endpoints. Download QMRF for model specific information"> </sup>
+                    <button type="button" class="select-all-btn" onclick="toggleTabModels(this)">Select all in this tab</button>
                     <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 10px;">
                         {% for model in models if model.case_study == 'thyroid' %}
                         <div class="model-tile {% if model.name in model_names %}checked{% endif %}">
@@ -154,6 +168,7 @@
 
                 <div id="pd" class="tab-pane fade">
                     <label>MIE models:</label><br>
+                    <button type="button" class="select-all-btn" onclick="toggleTabModels(this)">Select all in this tab</button>
                     <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 10px;">
                         {% for model in models if model.case_study == 'pd' %}
                         <div class="model-tile {% if model.name in model_names %}checked{% endif %}">
@@ -176,6 +191,7 @@
                 </div>
                 <div id="archived" class="tab-pane fade">
                         <label>MIE models:</label><br>
+                        <button type="button" class="select-all-btn" onclick="toggleTabModels(this)">Select all in this tab</button>
                         <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 10px;">
                             {% for model in models if model.case_study == 'archived' %}
                             <div class="model-tile {% if model.name in model_names %}checked{% endif %}">


### PR DESCRIPTION
Functional fixes ahead of the project-end (v1.0) version.

## Changes
- **#27 — Generate Report button**: it was wired to the form but `create_report()` was never called, so it did nothing. `/predict` now branches on `download_report` and returns the generated PDF (`qsprpred_report.pdf`).
- **#14 — 1-click model selection**: each model tab (Thyroid, PD, Archived) gets a "Select all in this tab" toggle that checks/unchecks every model in the active pane and fires the `change` event so tile highlighting stays in sync.
- **#41 — Applicability domain in the API**: `/api` now includes `within_applicability_domain (<model>)` per prediction for models that define an AD, across json/text/csv output.
- **#45 — `/get_models`**: new GET route returning model metadata (name, target, task, calculator, algorithm, case study) as JSON. Supersedes the open PR #45 (which had a URL bug).

## Testing
- Report: POST with `download_report=true` → valid 1-page `application/pdf` attachment.
- Select-all: 3 toggle buttons render; toggling updates tile state.
- API: AD field present in json and csv; normal prediction page still renders.
- `/get_models`: returns valid JSON for all 10 models.

Closes #27
Closes #14
Closes #41