### PR TITLE
Report ZIP bundle (PDF+CSV+QMRF+QPRF), fix duplicate tile IDs, tab consistency

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import time
+import zipfile
 
 import numpy as np
 import pandas as pd
@@ -441,7 +442,7 @@ def predict():
             # Check if any model has AD data
             if any(all_ads[m] for m in model_names):
                 row = [image_data] + [smile] + [
-                    all_predictions[m][i] + (f' ({str(all_ads[m][i])})' if all_ads[m] else '')
+                    all_predictions[m][i] + (f' ({format_ad(all_ads[m][i])})' if all_ads[m] else '')
                     for m in model_names
                 ]
             else:
@@ -559,15 +560,9 @@ def predict():
         log_prediction_time(used_ifp_model, len(smiles_list), elapsed_time)
         timing_stats = get_timing_stats()
 
-        # Generate a downloadable PDF report instead of re-rendering the page
+        # Generate a downloadable report bundle (PDF + CSV + QMRF + QPRF) instead of re-rendering
         if request.form.get('download_report'):
-            report_models = [model_info_dict[m] for m in model_names if m in model_info_dict]
-            # Drop the 'Structure' image column (col 0); keep SMILES + predictions as text
-            report_headers = headers[1:]
-            report_rows = [[row[1]] + [str(cell) for cell in row[2:]] for row in table_data]
-            report_buffer = create_report(report_models, report_headers, report_rows)
-            return send_file(report_buffer, as_attachment=True,
-                             download_name='qsprpred_report.pdf', mimetype='application/pdf')
+            return build_report_bundle(model_names, smiles_list, model_info_dict, headers, table_data)
 
         return render_template('index.html',
                                models=available_models,
@@ -587,6 +582,51 @@ def predict():
         logging.exception("An error occurred while processing the request.")
         timing_stats = get_timing_stats()
         return render_template('index.html', models=available_models, timing_stats=timing_stats, error="An error occurred while processing the request.")
+
+def format_ad(ad_value):
+    """Render an applicability-domain value as a readable label instead of a raw array."""
+    try:
+        flag = bool(ad_value[0]) if hasattr(ad_value, '__len__') else bool(ad_value)
+    except (TypeError, IndexError):
+        return str(ad_value)
+    return 'within AD' if flag else 'outside AD'
+
+
+def build_report_bundle(model_names, smiles_list, model_info_dict, headers, table_data):
+    """Build a ZIP with the summary PDF, a predictions CSV, and per-model QMRF /
+    per-prediction QPRF documents, and return it as a download."""
+    # Summary PDF (create_report mutates the rows it receives, so pass a fresh copy)
+    report_models = [model_info_dict[m] for m in model_names if m in model_info_dict]
+    report_headers = headers[1:]  # drop the 'Structure' image column
+    report_rows = [[row[1]] + [str(cell) for cell in row[2:]] for row in table_data]
+    pdf_buffer = create_report(report_models, report_headers, report_rows)
+
+    # Predictions CSV (rebuilt from the original table_data, text only)
+    csv_buffer = io.StringIO()
+    writer = csv.writer(csv_buffer)
+    writer.writerow(headers[1:])
+    for row in table_data:
+        writer.writerow([row[1]] + [str(cell) for cell in row[2:]])
+
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr('prediction_report.pdf', pdf_buffer.getvalue())
+        zf.writestr('predictions.csv', csv_buffer.getvalue())
+        for model_name in model_names:
+            # QMRF: per-model methodology document shipped alongside the model
+            qmrf_path = os.path.join(MODELS_DIR, model_name, f'qmrf_{model_name}.docx')
+            if os.path.exists(qmrf_path):
+                zf.write(qmrf_path, arcname=f'qmrf/{model_name}.docx')
+            # QPRF: per-prediction report generated during the prediction loop
+            for idx, smile in enumerate(smiles_list):
+                qprf_path = os.path.join('qprf', 'output', model_name, f'{smile}.docx')
+                if os.path.exists(qprf_path):
+                    safe = secure_filename(smile) or f'molecule_{idx + 1}'
+                    zf.write(qprf_path, arcname=f'qprf/{model_name}/{safe}.docx')
+    zip_buffer.seek(0)
+    return send_file(zip_buffer, as_attachment=True,
+                     download_name='qsprpred_report.zip', mimetype='application/zip')
+
 
 def create_report(model_info_list, headers, table_data):
     buffer = io.BytesIO()

--- a/templates/index.html
+++ b/templates/index.html
@@ -167,7 +167,7 @@
                 </div>
 
                 <div id="pd" class="tab-pane fade">
-                    <label>MIE models:</label><br>
+                    <label>MIE models:</label><sup><img src="/static/img/question-circle.svg" alt="Question circle" width="12" height="12" title="QSAR models for different endpoints. Download QMRF for model specific information"> </sup>
                     <button type="button" class="select-all-btn" onclick="toggleTabModels(this)">Select all in this tab</button>
                     <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 10px;">
                         {% for model in models if model.case_study == 'pd' %}
@@ -190,13 +190,13 @@
                 <p>MIE models for the nephrotoxicity case study are in progress.</p>
                 </div>
                 <div id="archived" class="tab-pane fade">
-                        <label>MIE models:</label><br>
+                        <label>MIE models:</label><sup><img src="/static/img/question-circle.svg" alt="Question circle" width="12" height="12" title="QSAR models for different endpoints. Download QMRF for model specific information"> </sup>
                         <button type="button" class="select-all-btn" onclick="toggleTabModels(this)">Select all in this tab</button>
                         <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 10px;">
                             {% for model in models if model.case_study == 'archived' %}
                             <div class="model-tile {% if model.name in model_names %}checked{% endif %}">
-                                <input type="checkbox" id="model_pd_{{ loop.index }}" name="model" value="{{ model.name }}" {% if model.name in model_names %}checked{% endif %}>
-                                <label for="model_pd_{{ loop.index }}">
+                                <input type="checkbox" id="model_archived_{{ loop.index }}" name="model" value="{{ model.name }}" {% if model.name in model_names %}checked{% endif %}>
+                                <label for="model_archived_{{ loop.index }}">
                                     <strong>{{ model.pref_name }}</strong><br>
                                     Model: {{ model.name }}<br>
                                     Property: {{ model.target_property_name }}<br>


### PR DESCRIPTION
Follow-up polish for the project-end version, prompted by a visual review of the model tabs and the report contents.

## Report bundle (extends #27)
The "Generate Report" button now returns a **ZIP** instead of a bare PDF:
```
qsprpred_report.zip
├── prediction_report.pdf      # model metadata + predictions
├── predictions.csv            # SMILES + predicted value + AD
├── qmrf/<model>.docx          # per-model QMRF methodology doc
└── qprf/<model>/<smiles>.docx # per-prediction QPRF (already generated by the app)
```
This gives users the regulatory read-across/QMRF/QPRF evidence, not just a value.

## Bug: duplicate checkbox IDs in the Archived tab
Archived tiles reused the PD tab's IDs (`model_pd_1/2`), so clicking the first two Archived tile **labels** toggled PD models instead (confirmed in-browser: clicking "GABA" checked `4or2_final`). Archived now uses `model_archived_N`.

## Consistency + formatting
- PD and Archived panes now show the same help icon + "Select all in this tab" layout as Thyroid (previously the button dropped to a second line with no icon).
- Applicability domain renders as `within AD` / `outside AD` instead of the raw `([ True])` array — in the web table, PDF, and CSV.

## Testing
- ZIP returned with correct `application/zip` headers; verified contents for single- and multi-model requests (QMRF + QPRF per model, PDF, CSV).
- CSV/PDF show clean AD labels and all valid rows.
- Confirmed no duplicate model IDs and all three tabs render the help icon + button.