### PR TITLE
Reject duplicate inputs, graceful docking failure, fix stuck report spinner

### DIFF
--- a/app.py
+++ b/app.py
@@ -364,6 +364,19 @@ def predict():
             timing_stats = get_timing_stats()
             return render_template('index.html', models=available_models, timing_stats=timing_stats, error=error_message)
 
+        # Identical structures (e.g. the same molecule written two ways) standardize to
+        # the same SMILES and collapse to a single entry in the docking store, which
+        # breaks the per-molecule mapping. Reject duplicates up front with a clear,
+        # fast message instead of failing deep in the (slow) docking pipeline.
+        unique_smiles = list(dict.fromkeys(smiles_list))
+        if len(unique_smiles) < len(smiles_list):
+            error_message = (f"Duplicate structures detected: {len(smiles_list)} molecules were "
+                             f"submitted but only {len(unique_smiles)} are unique after "
+                             "standardization. Please submit each unique structure once.")
+            logging.error(error_message)
+            timing_stats = get_timing_stats()
+            return render_template('index.html', models=available_models, timing_stats=timing_stats, error=error_message)
+
         store_names = []
         all_predictions = {}
         all_raw_predictions = {}
@@ -578,6 +591,10 @@ def predict():
                                elapsed_time=elapsed_time,
                                timing_stats=timing_stats,
                                error=error_message)
+    except ifp.DockingError as e:
+        logging.warning(f"Docking could not complete: {e}")
+        timing_stats = get_timing_stats()
+        return render_template('index.html', models=available_models, timing_stats=timing_stats, error=str(e))
     except Exception:
         logging.exception("An error occurred while processing the request.")
         timing_stats = get_timing_stats()
@@ -624,8 +641,14 @@ def build_report_bundle(model_names, smiles_list, model_info_dict, headers, tabl
                     safe = secure_filename(smile) or f'molecule_{idx + 1}'
                     zf.write(qprf_path, arcname=f'qprf/{model_name}/{safe}.docx')
     zip_buffer.seek(0)
-    return send_file(zip_buffer, as_attachment=True,
-                     download_name='qsprpred_report.zip', mimetype='application/zip')
+    response = send_file(zip_buffer, as_attachment=True,
+                         download_name='qsprpred_report.zip', mimetype='application/zip')
+    # Echo the client's download token back as a cookie so the UI knows the file was
+    # delivered and can dismiss the loading overlay (the page itself never navigates).
+    token = request.form.get('download_token')
+    if token:
+        response.set_cookie('fileDownloadToken', token, max_age=60)
+    return response
 
 
 def create_report(model_info_list, headers, table_data):

--- a/ifp.py
+++ b/ifp.py
@@ -15,6 +15,10 @@ from spock.storage import TabularStorage
 from spock.utils.standardizers.papyrus import PapyrusStandardizer
 
 
+class DockingError(Exception):
+    """Raised when one or more molecules fail to dock, so the batch cannot complete."""
+
+
 def initialize(lib_name, lib_path):
     # load molecules
     standardizer = PapyrusStandardizer()
@@ -180,6 +184,18 @@ def predict(smiles_list, model, protein_id, prep):
     bits_aligned = get_IFPs(store, protein_id)
     bits_aligned = bits_aligned.drop(columns=["ID"])
 
+    # A molecule that fails to dock produces no poses and is dropped, leaving fewer
+    # rows than inputs. Detect that and fail with a clear message instead of crashing
+    # on the positional indexing below.
+    n_docked = min(len(store._df), len(bits_aligned))
+    if n_docked < len(smiles_list):
+        n_failed = len(smiles_list) - n_docked
+        raise DockingError(
+            f"{n_failed} of {len(smiles_list)} submitted molecule(s) could not be docked "
+            "against this target. Docking-based models need a successful pose for every "
+            "molecule; please submit the molecules individually or remove the structure(s) "
+            "that fail to dock."
+        )
 
     df = store._df.iloc[range(len(smiles_list))]
     file_name = "table"

--- a/templates/index.html
+++ b/templates/index.html
@@ -224,6 +224,7 @@
             {% endif %}
             <br>
 
+            <input type="hidden" id="download_token" name="download_token" value="">
             <input type="submit" value="Run">
             <button type="submit" name="download_report" value="true">Generate Report</button>
         </div>
@@ -440,7 +441,15 @@
             return numMolecules * timePerMolecule * numModels;
         }
 
-        document.querySelector('form').addEventListener('submit', function() {
+        function hideLoadingOverlay() {
+            document.getElementById('loading-overlay').style.display = 'none';
+            if (timerInterval) {
+                clearInterval(timerInterval);
+                timerInterval = null;
+            }
+        }
+
+        document.querySelector('form').addEventListener('submit', function(event) {
             document.getElementById('loading-overlay').style.display = 'flex';
             elapsedSeconds = 0;
             document.getElementById('elapsed-timer').textContent = 'Elapsed: 0:00';
@@ -458,6 +467,24 @@
                 elapsedSeconds++;
                 document.getElementById('elapsed-timer').textContent = 'Elapsed: ' + formatTimerDisplay(elapsedSeconds);
             }, 1000);
+
+            // The report download returns a file, so the page never navigates and the
+            // overlay would otherwise stay up forever. Tag the request with a token; the
+            // server echoes it back as a cookie when the file is sent, and we poll for it.
+            var submitter = event.submitter;
+            if (submitter && submitter.name === 'download_report') {
+                var token = 'dl_' + Date.now() + '_' + Math.floor(Math.random() * 1e9);
+                document.getElementById('download_token').value = token;
+                var poll = setInterval(function() {
+                    if (document.cookie.indexOf('fileDownloadToken=' + token) !== -1) {
+                        clearInterval(poll);
+                        document.cookie = 'fileDownloadToken=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+                        hideLoadingOverlay();
+                    }
+                }, 500);
+                // Safety net: never leave the overlay stuck if the cookie is missed
+                setTimeout(function() { clearInterval(poll); hideLoadingOverlay(); }, 300000);
+            }
         });
     </script>
 </body>


### PR DESCRIPTION
Fixes three issues found while testing report generation on the live endpoint.

## 1. Duplicate inputs crash the docking models
Two SMILES that standardize to the **same molecule** (e.g. T3 written two ways: `N[C@@H](Cc1cc(I)c(Oc2ccc(O)c(I)c2)c(I)c1)C(O)=O` and `OC(=O)[C@@H](N)Cc1cc(I)c(c(I)c1)Oc2ccc(O)c(I)c2`) collapse to a single entry in the docking store. The per-molecule mapping in `ifp.predict` then crashes with `IndexError: positional indexers are out-of-bounds` — but only *after* the full ~1-minute Vina run. Now identical standardized inputs are detected up front and rejected with a clear, immediate message.

## 2. Genuine docking failures crash the batch
If a molecule legitimately fails to dock it's dropped during pose generation, again breaking the row mapping. Added a `DockingError` with an actionable message, surfaced to the user instead of the generic "An error occurred."

## 3. Loading spinner never dismisses after a report download
The report returns a file, so the page never navigates and the overlay stayed up. The client now tags the report request with a token; the server echoes it as a `fileDownloadToken` cookie when the file is delivered, and the UI polls for it to dismiss the overlay (with a 5-min timeout safety net).

## Testing (local)
- The two T3 SMILES → duplicate error in 0.9 s (was a >1-min crash).
- Two distinct SMILES → normal predictions, no false trigger.
- Report bundle → `Set-Cookie: fileDownloadToken=...`; valid zip; no cookie when no token.

## Known issue (not in this PR)
The archived RF models have no QMRF file, so their "Download QMRF here" tile link 500s. The report bundle already skips missing QMRFs gracefully.