### PR TITLE
Hide QMRF link for models without a QMRF document

### DIFF
--- a/app.py
+++ b/app.py
@@ -210,6 +210,7 @@ def extract_model_info(directory):
             with open(meta_path, 'r') as meta_file:
                 meta_data = json.load(meta_file)
                 state = meta_data['py/state']
+                curr_dir = os.path.join(directory, d)
                 model_info = {
                     'name': state['name'],
                     'pref_name': state['pref_name'],
@@ -218,7 +219,9 @@ def extract_model_info(directory):
                     'target_property_task': state['targetProperties'][0]['py/state']['task']['py/reduce'][1]['py/tuple'][0],
                     'feature_calculator': state['featureCalculators'][0]['py/object'].split('.')[-1],
                     'algorithm': state['alg'].split('.')[-1],
-                    'currDir': os.path.join(directory, d),
+                    'currDir': curr_dir,
+                    # Only some models ship a QMRF document; used to hide a dead download link
+                    'has_qmrf': os.path.isfile(os.path.join(curr_dir, f"qmrf_{state['name']}.docx")),
                 }
                 models_info.append(model_info)
                 logging.info(f"Loaded model metadata: {model_info}")
@@ -228,7 +231,10 @@ def extract_model_info(directory):
 def download_qmrf():
     path = request.args.get('path')
     target = request.args.get('target')
-    return send_file(path + f'/qmrf_{target}.docx', as_attachment=True)
+    qmrf_path = f'{path}/qmrf_{target}.docx'
+    if not os.path.isfile(qmrf_path):
+        return jsonify({'error': f'No QMRF document is available for {target}.'}), 404
+    return send_file(qmrf_path, as_attachment=True)
 
 @app.route('/downloadqprf')
 def download_qprf():

--- a/static/styles.css
+++ b/static/styles.css
@@ -261,3 +261,9 @@ th {
     color: #fff;
     background: #E6007E;
 }
+
+.qmrf-missing {
+    color: #888;
+    font-style: italic;
+    font-size: 13px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -159,7 +159,7 @@
                                 Task: {{ model.target_property_task }}<br>
                                 Calculator: {{ model.feature_calculator }}<br>
                                 Algorithm: {{ model.algorithm }}<br>
-                                <a href="{{ url_for('download_qmrf', path=model.currDir, target=model.name) }}">Download QMRF here</a>
+                                {% if model.has_qmrf %}<a href="{{ url_for('download_qmrf', path=model.currDir, target=model.name) }}">Download QMRF here</a>{% else %}<span class="qmrf-missing">QMRF not available</span>{% endif %}
                             </label>
                         </div>
                         {% endfor %}
@@ -180,7 +180,7 @@
                                 Task: {{ model.target_property_task }}<br>
                                 Calculator: {{ model.feature_calculator }}<br>
                                 Algorithm: {{ model.algorithm }}<br>
-								<a href="{{ url_for('download_qmrf', path=model.currDir, target=model.name) }}">Download QMRF here</a>
+								{% if model.has_qmrf %}<a href="{{ url_for('download_qmrf', path=model.currDir, target=model.name) }}">Download QMRF here</a>{% else %}<span class="qmrf-missing">QMRF not available</span>{% endif %}
                             </label>
                         </div>
                         {% endfor %}
@@ -203,7 +203,7 @@
                                     Task: {{ model.target_property_task }}<br>
                                     Calculator: {{ model.feature_calculator }}<br>
                                     Algorithm: {{ model.algorithm }}<br>
-                                    <a href="{{ url_for('download_qmrf', path=model.currDir, target=model.name) }}">Download QMRF here</a>
+                                    {% if model.has_qmrf %}<a href="{{ url_for('download_qmrf', path=model.currDir, target=model.name) }}">Download QMRF here</a>{% else %}<span class="qmrf-missing">QMRF not available</span>{% endif %}
                                 </label>
                             </div>
                             {% endfor %}


### PR DESCRIPTION
The 5 archived RF models ship no `qmrf_<name>.docx`, so their "Download QMRF here" tile link returned a 500. `extract_model_info` now records a `has_qmrf` flag; the template renders the link only when the document exists, otherwise a muted "QMRF not available" note. The `/download` route also returns a clean 404 instead of a 500 if hit with a missing file.

## Testing (local)
- Thyroid + PD tabs: QMRF link shown (those models have QMRFs).
- Archived tab: all 5 show "QMRF not available", no broken links.
- `/download` → 404 JSON for missing, 200 docx for present.