### PR TITLE
Project-end v1.0.0: archival README + citation metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,35 @@
+{
+  "title": "QSPRpred-Docker",
+  "description": "A Dockerized web service built on QSPRpred for predicting chemical bioactivity at molecular initiating events (MIEs) from the VHP4Safety case studies (thyroid, Parkinson's disease, nephrotoxicity), with a web user interface and a JSON/CSV API. Project-end archived version (v1.0.0) produced during the VHP4Safety project.",
+  "upload_type": "software",
+  "license": "MIT",
+  "version": "1.0.0",
+  "keywords": [
+    "QSAR",
+    "QSPRpred",
+    "VHP4Safety",
+    "cheminformatics",
+    "bioactivity prediction",
+    "molecular initiating event"
+  ],
+  "creators": [
+    {
+      "name": "Martens, Marvin",
+      "orcid": "0000-0003-2230-0840",
+      "affiliation": "Maastricht University"
+    },
+    {
+      "name": "Schoenmaker, Linde",
+      "affiliation": "Leiden University, LACDR"
+    },
+    {
+      "name": "Çınar, Ozan"
+    },
+    {
+      "name": "Davidse, Sam"
+    },
+    {
+      "name": "Rhadekz"
+    }
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,38 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: QSPRpred-Docker
+abstract: >-
+  A Dockerized web service built on QSPRpred for predicting chemical bioactivity
+  at molecular initiating events (MIEs) from the VHP4Safety case studies (thyroid,
+  Parkinson's disease, nephrotoxicity), with a web user interface and a JSON/CSV API.
+  This is the project-end archived version produced during the VHP4Safety project.
+type: software
+version: 1.0.0
+date-released: "2026-06-01"
+license: MIT
+repository-code: "https://github.com/VHP4Safety/QSPRpred-Docker"
+url: "https://qsprpred.cloud.vhp4safety.nl"
+keywords:
+  - QSAR
+  - QSPRpred
+  - VHP4Safety
+  - cheminformatics
+  - bioactivity prediction
+  - molecular initiating event
+authors:
+  - family-names: Martens
+    given-names: Marvin
+    orcid: "https://orcid.org/0000-0003-2230-0840"
+    affiliation: "Maastricht University"
+  - family-names: Schoenmaker
+    given-names: Linde
+    affiliation: "Leiden University, LACDR"
+    # TODO: confirm ORCID
+  - family-names: Çınar
+    given-names: Ozan
+    # TODO: confirm affiliation and ORCID
+  - family-names: Davidse
+    given-names: Sam
+    # TODO: confirm given-name spelling, affiliation, and ORCID
+  - name: "Rhadekz"
+    # TODO: replace GitHub handle with full name, affiliation, and ORCID

--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
 # QSPRpred-Docker
 
-This GitHub repo is set up for the development of a Docker-based service on the QSPRpred tool [github.com/CDDLeiden/QSPRpred](https://github.com/CDDLeiden/QSPRpred). In the initial stage, the service will have prediction functionalities based on imported, pre-trained model(s). 
+A Docker-based prediction service built on the QSPRpred tool [github.com/CDDLeiden/QSPRpred](https://github.com/CDDLeiden/QSPRpred). It provides a web UI and a JSON/CSV API for predicting chemical bioactivity at molecular initiating events (MIEs) from the VHP4Safety case studies (thyroid, Parkinson's disease, nephrotoxicity), using imported pre-trained models.
+
+> ## 📦 Project-end archived version (v1.0.0)
+>
+> This repository is the **project-end snapshot** of the QSPRpred-Docker service,
+> developed during the [VHP4Safety](https://www.vhp4safety.nl/) project. The project
+> has concluded, so the repository is **archived (read-only)** and no longer actively
+> maintained. It is preserved as a citable artifact of the work.
+>
+> - **Live service:** https://qsprpred.cloud.vhp4safety.nl (available while the VHP4Safety cluster is maintained)
+> - **Container image:** `ghcr.io/vhp4safety/qsprpred-docker:latest` (see [Self-hosting](#self-hosting) to run it yourself)
+> - **Built on:** QSPRpred 3.1.1
+> - Remaining ideas and caveats are recorded under [Future Work](#future-work) and [Known Limitations](#known-limitations).
+>
+> <!-- DOI-BADGE -->
 
 ## Flask Application Deployment with Docker
-[![Docker Image CI](https://github.com/VHP4Safety/QSPRpred-Docker/actions/workflows/docker-image.yml/badge.svg)](https://github.com/VHP4Safety/QSPRpred-Docker/actions/workflows/docker-image.yml)
+[![Publish Docker image](https://github.com/VHP4Safety/QSPRpred-Docker/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/VHP4Safety/QSPRpred-Docker/actions/workflows/docker-publish.yml)
 
 This guide covers the setup and usage of a Flask application for predictions via a Docker container. The application provides both a user interface for interacting with the model and an API for programmatic access.
 
@@ -18,6 +32,17 @@ Run the Docker container with the following command. This command also mounts a 
 docker run -d -p 5000:5000 --name qspr_flask_container -v $(pwd)/models:/usr/src/app/models  qspr_flask_image
 ```
 
+### Self-hosting
+You do not need to build the image — the project-end image is published to the GitHub
+Container Registry with the pretrained models, data, and QMRF documents baked in. Pull
+and run it directly:
+```sh
+docker run -d -p 5000:5000 --name qsprpred ghcr.io/vhp4safety/qsprpred-docker:latest
+```
+Then open http://localhost:5000. No volume mount is required (the models live inside the
+image). This is the same image that runs the live service at
+https://qsprpred.cloud.vhp4safety.nl.
+
 ### Accessing the Application
 Once the container is running, navigate to http://localhost:5000 in your web browser. You will see the Flask application interface which allows you to:
 
@@ -28,15 +53,22 @@ Once the container is running, navigate to http://localhost:5000 in your web bro
 ![QSPRpred UI](qsprpred-ui.png?raw=true "UI")
 
 ### Using the API
-You can also interact with the Flask application via its API from your coding environment. Below are examples of how to use the API:
+You can also interact with the Flask application via its API from your coding environment.
+Use `GET /get_models` to list the available models and their metadata:
+```sh
+curl localhost:5000/get_models
+```
+For models that define an applicability domain, prediction responses include a
+`within_applicability_domain (<model>)` field alongside the predicted value. Below are
+examples of how to use the prediction endpoint:
 
 #### Example: JSON Output
 To initiate a prediction and receive the results in JSON format, use:
 ```sh
 curl -X POST localhost:5000/api     -H "Content-Type: application/json"     -d '{
         "smiles": ["C1=CC=CC=C1C(=O)NC2=CC=CC=C2", "CC(=O)OC1=CC=CC=C1C(=O)O"],
-        "models": ["P10827_RF_Model", "P10828_RF_Model"],
-        "format": "text"
+        "models": ["TRalpha", "TRbeta"],
+        "format": "json"
     }'
 ```
 #### Example: CSV Output
@@ -44,7 +76,7 @@ To receive the prediction results as a CSV file, use:
 ```sh
 curl -X POST localhost:5000/api     -H "Content-Type: application/json"     -d '{
         "smiles": ["C1=CC=CC=C1C(=O)NC2=CC=CC=C2", "CC(=O)OC1=CC=CC=C1C(=O)O"],
-        "models": ["P10827_RF_Model", "P10828_RF_Model"],
+        "models": ["TRalpha", "TRbeta"],
         "format": "csv"
     }' -o predictions.csv
 ```
@@ -65,3 +97,19 @@ The application includes interaction fingerprint (IFP) models that use molecular
 - **8t6j_b_final** - mGluR5 receptor model
 
 These models use AutoDock Vina for molecular docking and are slower than MorganFP-based models (~30-60 seconds per molecule). They are available in the "Parkinson's Disease" tab.
+
+## Future Work
+The project concluded before these enhancements were implemented. They are recorded here for anyone who continues the tool (original issue numbers in brackets):
+
+- **Richer model metadata / provenance** — surface what each model was trained on, its container/version details, and pretrained-model information on the tiles ([#11](https://github.com/VHP4Safety/QSPRpred-Docker/issues/11), [#30](https://github.com/VHP4Safety/QSPRpred-Docker/issues/30), [#34](https://github.com/VHP4Safety/QSPRpred-Docker/issues/34)).
+- **Analogue searcher** — a similarity-search UI against a model's training set ([#26](https://github.com/VHP4Safety/QSPRpred-Docker/issues/26)).
+- **Model performance view** — show held-out performance metrics/plots per model ([#28](https://github.com/VHP4Safety/QSPRpred-Docker/issues/28)).
+- **Structural-difference highlighting** — highlight structural differences in the nearest-neighbour table ([#40](https://github.com/VHP4Safety/QSPRpred-Docker/issues/40)).
+- **Persist generated data** — save prediction outputs on the platform across sessions ([#33](https://github.com/VHP4Safety/QSPRpred-Docker/issues/33)).
+- **ChEMBL lookup** — look up experimental pChEMBL values in ChEMBL for submitted compounds ([#10](https://github.com/VHP4Safety/QSPRpred-Docker/issues/10)).
+
+## Known Limitations
+- **pChEMBL is an aggregated proxy.** Predicted pChEMBL values are derived from heterogeneous assays (different assay types, conditions, and biological relevance), so they should be interpreted as a relative potency indicator, not an absolute measurement ([#35](https://github.com/VHP4Safety/QSPRpred-Docker/issues/35)).
+- **Predictions are point estimates.** Models do not output confidence/prediction intervals ([#29](https://github.com/VHP4Safety/QSPRpred-Docker/issues/29)).
+- **Docking models are slow and strict.** The Parkinson's Disease IFP/docking models (`4or2_final`, `8t6j_b_final`) run AutoDock Vina (~30–60 s per molecule), require each batch to contain unique structures (identical molecules submitted together are rejected), and fail a request if any molecule cannot be docked.
+- **No QMRF for archived models.** The models in the "Archived" tab do not ship a QMRF document; their tiles show "QMRF not available".


### PR DESCRIPTION
Archival wrap-up for the project-end version (#48). No functional code changes — docs and metadata only.

## Changes
- **README archival notice** — marks this as the project-end (v1.0.0) snapshot, links the live service and the GHCR image, and includes a DOI-badge placeholder (filled once Zenodo mints the DOI).
- **Self-hosting section** — `docker run ghcr.io/vhp4safety/qsprpred-docker:latest` (models baked in, no mount needed).
- **Future Work** and **Known Limitations** sections — capture the closed issues (#10, #11/#30/#34, #26, #28, #33, #40 as future work; #35, #29 + docking/QMRF caveats as limitations).
- Fixed the stale CI badge (`docker-image.yml` → `docker-publish.yml`) and the API examples (real model names, `/get_models`, applicability-domain field).
- **CITATION.cff** (validated against CFF 1.2.0) and **.zenodo.json** so the release is citable and the Zenodo DOI record is well described. Some contributor ORCIDs/names are flagged `# TODO` for confirmation.

Part of #48.